### PR TITLE
Create simple Transcript and Summarygenerator class interfaces

### DIFF
--- a/qt-app/qt-app.pro
+++ b/qt-app/qt-app.pro
@@ -15,6 +15,7 @@ SOURCES += \
     mainwindow.cpp \
     patientrecord.cpp \
     windowbuilder.cpp \
+    transcript.cpp \
     summary.cpp \
     summarygenerator.cpp
 
@@ -24,6 +25,7 @@ HEADERS += \
     mainwindow.h \
     patientrecord.h \
     windowbuilder.h \
+    transcript.h \
     summary.h \
     summarygenerator.h
 

--- a/qt-app/qt-app.pro
+++ b/qt-app/qt-app.pro
@@ -15,7 +15,8 @@ SOURCES += \
     mainwindow.cpp \
     patientrecord.cpp \
     windowbuilder.cpp \
-    summary.cpp
+    summary.cpp \
+    summarygenerator.cpp
 
 HEADERS += \
     filehandler.h \
@@ -23,7 +24,8 @@ HEADERS += \
     mainwindow.h \
     patientrecord.h \
     windowbuilder.h \
-    summary.h
+    summary.h \
+    summarygenerator.h
 
 FORMS += \
     mainwindow.ui

--- a/qt-app/summary.cpp
+++ b/qt-app/summary.cpp
@@ -8,7 +8,7 @@
 
 #include "summary.h"
 
-Summary::Summary(QObject *parent) : QObject(parent)
+Summary::Summary()
 {
     // No logic body; QStrings get initialized to null by default
 }

--- a/qt-app/summary.cpp
+++ b/qt-app/summary.cpp
@@ -13,14 +13,9 @@ Summary::Summary()
     // No logic body; QStrings get initialized to null by default
 }
 
-Summary::~Summary()
-{
-    // Qt automatically manages memory of QObjects, no need for manual deletion
-}
-
 /**
  * @name getSymptoms
- * @brief Get summary of symptoms
+ * @brief Get a read-only summary of symptoms
  * @return Summary of symptoms
  */
 const QString& Summary::getSymptoms()
@@ -30,7 +25,7 @@ const QString& Summary::getSymptoms()
 
 /**
  * @name getDiagnoses
- * @brief Get summary of diagnoses
+ * @brief Get a read-only summary of diagnoses
  * @return Summary of diagnoses
  */
 const QString& Summary::getDiagnoses()
@@ -40,7 +35,7 @@ const QString& Summary::getDiagnoses()
 
 /**
  * @name getMedicalHistory
- * @brief Get summary of medical history
+ * @brief Get a read-only summary of medical history
  * @return Summary of medical history
  */
 const QString& Summary::getMedicalHistory()
@@ -50,7 +45,7 @@ const QString& Summary::getMedicalHistory()
 
 /**
  * @name getTreatmentPlans
- * @brief Get summary of treatment plans
+ * @brief Get a read-only summary of treatment plans
  * @return Summary of treatment plans
  */
 const QString& Summary::getTreatmentPlans()

--- a/qt-app/summary.h
+++ b/qt-app/summary.h
@@ -11,12 +11,11 @@
 
 #include <QObject>
 
-class Summary : public QObject
+class Summary
 {
-    Q_OBJECT
 
     public:
-        explicit Summary(QObject *parent = nullptr);
+        Summary();
         ~Summary();
 
         const QString& getSymptoms();

--- a/qt-app/summary.h
+++ b/qt-app/summary.h
@@ -9,14 +9,14 @@
 #ifndef SUMMARY_H
 #define SUMMARY_H
 
-#include <QObject>
+#include <QString>
 
 class Summary
 {
 
     public:
         Summary();
-        ~Summary();
+        ~Summary() = default;  // Qt automatically manages memory of QObjects, no need for manual deletion
 
         const QString& getSymptoms();
         const QString& getDiagnoses();
@@ -36,4 +36,4 @@ class Summary
 
 };
 
-#endif
+#endif // SUMMARY_H

--- a/qt-app/summarygenerator.cpp
+++ b/qt-app/summarygenerator.cpp
@@ -8,7 +8,8 @@
 
 #include "summarygenerator.h"
 
-SummaryGenerator::SummaryGenerator(const Transcript& transcript) : transcript(transcript)
+SummaryGenerator::SummaryGenerator(QObject *parent) 
+    : QObject(parent)
 {
     // No logic body
 }
@@ -40,4 +41,9 @@ SummaryGenerator& SummaryGenerator::summarizeTreatmentPlans()
 Summary SummaryGenerator::getSummary()
 {
     return summary;
+}
+
+SummaryGenerator::~SummaryGenerator()
+{
+    // Qt automatically manages memory of QObjects, no need for manual deletion
 }

--- a/qt-app/summarygenerator.cpp
+++ b/qt-app/summarygenerator.cpp
@@ -8,7 +8,7 @@
 
 #include "summarygenerator.h"
 
-SummaryGenerator::SummaryGenerator()
+SummaryGenerator::SummaryGenerator(const Transcript& transcript) : transcript(transcript)
 {
     // No logic body
 }

--- a/qt-app/summarygenerator.cpp
+++ b/qt-app/summarygenerator.cpp
@@ -1,0 +1,43 @@
+/**
+ * @name summarygenerator.cpp
+ * @brief Definition of SummaryGenerator builder class
+ * 
+ * @author Joelene Hales (jhales5@uwo.ca)
+ * @date Mar. 9, 2025
+ */
+
+#include "summarygenerator.h"
+
+SummaryGenerator::SummaryGenerator()
+{
+    // No logic body
+}
+
+SummaryGenerator& SummaryGenerator::summarizeSymptoms()
+{
+    // TODO: Implement
+    return *this;
+}
+
+SummaryGenerator& SummaryGenerator::summarizeDiagnoses()
+{
+    // TODO: Implement
+    return *this;
+}
+
+SummaryGenerator& SummaryGenerator::summarizeMedicalHistory()
+{
+    // TODO: Implement
+    return *this;
+}
+
+SummaryGenerator& SummaryGenerator::summarizeTreatmentPlans()
+{
+    // TODO: Implement
+    return *this;
+}
+
+Summary SummaryGenerator::getSummary()
+{
+    return summary;
+}

--- a/qt-app/summarygenerator.cpp
+++ b/qt-app/summarygenerator.cpp
@@ -6,35 +6,60 @@
  * @date Mar. 9, 2025
  */
 
+#include <QDebug>
 #include "summarygenerator.h"
 
-SummaryGenerator::SummaryGenerator(QObject *parent) 
-    : QObject(parent)
+SummaryGenerator::SummaryGenerator(Transcript& transcript, QObject *parent)
+    : QObject(parent), transcript(transcript)
 {
     // No logic body
 }
 
 SummaryGenerator& SummaryGenerator::summarizeSymptoms()
 {
-    // TODO: Implement
+    // TODO: Implement LLM summarization and replace this placeholder string
+    QString currentTime = QTime::currentTime().toString("hh:mm:ss");
+    QString placeholderText = "Symptoms summary... (Generated at: " + currentTime + ")";
+    
+    qDebug() << "Generated summary of symptoms at " << currentTime;
+    summary.setSymptoms(placeholderText);
+
     return *this;
 }
 
 SummaryGenerator& SummaryGenerator::summarizeDiagnoses()
 {
-    // TODO: Implement
+    // TODO: Implement LLM summarization and replace this placeholder string
+    QString currentTime = QTime::currentTime().toString("hh:mm:ss");
+    QString placeholderText = "Diagnoses summary... (Generated at: " + currentTime + ")";
+    
+    qDebug() << "Generated summary of diagnoses at " << currentTime;
+    summary.setDiagnoses(placeholderText);
+    
     return *this;
 }
 
 SummaryGenerator& SummaryGenerator::summarizeMedicalHistory()
 {
-    // TODO: Implement
+    // TODO: Implement LLM summarization and replace this placeholder string
+    QString currentTime = QTime::currentTime().toString("hh:mm:ss");
+    QString placeholderText = "Medical history summary... (Generated at: " + currentTime + ")";
+    
+    qDebug() << "Generated summary of medical history at " << currentTime;
+    summary.setMedicalHistory(placeholderText);
+
     return *this;
 }
 
 SummaryGenerator& SummaryGenerator::summarizeTreatmentPlans()
 {
-    // TODO: Implement
+    // TODO: Implement LLM summarization and replace this placeholder string
+    QString currentTime = QTime::currentTime().toString("hh:mm:ss");
+    QString placeholderText = "Treatment plans summary... (Generated at: " + currentTime + ")";
+    
+    qDebug() << "Generated summary of treatment plans at " << currentTime;
+    summary.setTreatmentPlans(placeholderText);
+
     return *this;
 }
 

--- a/qt-app/summarygenerator.cpp
+++ b/qt-app/summarygenerator.cpp
@@ -9,12 +9,28 @@
 #include <QDebug>
 #include "summarygenerator.h"
 
+/**
+ * @name SummaryGenerator
+ * @brief Constructor for the SummaryGenerator class
+ * @details Implements the Builder design pattern to create a Summary object.
+ *          Add desired elements to the summary by calling the corresponding method.
+ * @param[in] transcript: Transcript to summarize
+ *                        TODO: This functionality is currently not implemented.
+ *                        Summaries are simply placeholder text
+ * @param[in] parent: Parent object in Qt application
+ */
 SummaryGenerator::SummaryGenerator(Transcript& transcript, QObject *parent)
     : QObject(parent), transcript(transcript)
 {
     // No logic body
 }
 
+
+/**
+ * @name summarizeSymptoms
+ * @brief Summarizes symptoms discussed in the transcript
+ * @return Reference to the builder. This allows methods to be chained together.
+ */
 SummaryGenerator& SummaryGenerator::summarizeSymptoms()
 {
     // TODO: Implement LLM summarization and replace this placeholder string
@@ -27,6 +43,12 @@ SummaryGenerator& SummaryGenerator::summarizeSymptoms()
     return *this;
 }
 
+
+/**
+ * @name summarizeDiagnoses
+ * @brief Summarizes diagnoses discussed in the transcript
+ * @return Reference to the builder. This allows methods to be chained together.
+ */
 SummaryGenerator& SummaryGenerator::summarizeDiagnoses()
 {
     // TODO: Implement LLM summarization and replace this placeholder string
@@ -39,6 +61,12 @@ SummaryGenerator& SummaryGenerator::summarizeDiagnoses()
     return *this;
 }
 
+
+/**
+ * @name summarizeMedicalHistory
+ * @brief Summarizes medical history discussed in the transcript
+ * @return Reference to the builder. This allows methods to be chained together.
+ */
 SummaryGenerator& SummaryGenerator::summarizeMedicalHistory()
 {
     // TODO: Implement LLM summarization and replace this placeholder string
@@ -51,6 +79,12 @@ SummaryGenerator& SummaryGenerator::summarizeMedicalHistory()
     return *this;
 }
 
+
+/**
+ * @name summarizeTreatmentPlans
+ * @brief Summarizes treatment plans discussed in the transcript
+ * @return Reference to the builder. This allows methods to be chained together.
+ */
 SummaryGenerator& SummaryGenerator::summarizeTreatmentPlans()
 {
     // TODO: Implement LLM summarization and replace this placeholder string
@@ -63,12 +97,13 @@ SummaryGenerator& SummaryGenerator::summarizeTreatmentPlans()
     return *this;
 }
 
+
+/**
+ * @brief getSummary
+ * @brief Get the summary generated
+ * @return Generated summary
+ */
 Summary SummaryGenerator::getSummary()
 {
     return summary;
-}
-
-SummaryGenerator::~SummaryGenerator()
-{
-    // Qt automatically manages memory of QObjects, no need for manual deletion
 }

--- a/qt-app/summarygenerator.h
+++ b/qt-app/summarygenerator.h
@@ -1,7 +1,6 @@
 /**
  * @name summarygenerator.h
  * @brief Declaration of SummaryGenerator builder class
- * TODO: Add to documentation explaining design patterns
  * 
  * @author Joelene Hales (jhales5@uwo.ca)
  * @date Mar. 9, 2025
@@ -20,7 +19,7 @@ class SummaryGenerator : public QObject
 
     public:
         explicit SummaryGenerator(Transcript& transcript, QObject *parent = nullptr);
-        virtual ~SummaryGenerator();
+        virtual ~SummaryGenerator() = default;  // Qt automatically manages memory of QObjects, no need for manual deletion
 
         SummaryGenerator& summarizeSymptoms();
         SummaryGenerator& summarizeDiagnoses();

--- a/qt-app/summarygenerator.h
+++ b/qt-app/summarygenerator.h
@@ -1,0 +1,33 @@
+/**
+ * @name summarygenerator.h
+ * @brief Declaration of SummaryGenerator builder class
+ * TODO: Add to documentation explaining design patterns
+ * 
+ * @author Joelene Hales (jhales5@uwo.ca)
+ * @date Mar. 9, 2025
+ */
+
+#ifndef SUMMARYGENERATOR_H
+#define SUMMARYGENERATOR_H
+
+#include "summary.h"
+
+class SummaryGenerator
+{
+
+    public:
+        SummaryGenerator();
+        ~SummaryGenerator() = default;
+
+        SummaryGenerator& summarizeSymptoms();
+        SummaryGenerator& summarizeDiagnoses();
+        SummaryGenerator& summarizeMedicalHistory();
+        SummaryGenerator& summarizeTreatmentPlans();
+        Summary getSummary();
+
+    private:
+        Summary summary;
+
+};
+
+#endif // SUMMARYGENERATOR_H

--- a/qt-app/summarygenerator.h
+++ b/qt-app/summarygenerator.h
@@ -10,13 +10,14 @@
 #ifndef SUMMARYGENERATOR_H
 #define SUMMARYGENERATOR_H
 
+#include "transcript.h"
 #include "summary.h"
 
 class SummaryGenerator
 {
 
     public:
-        SummaryGenerator();
+        SummaryGenerator(const Transcript& transcript);
         ~SummaryGenerator() = default;
 
         SummaryGenerator& summarizeSymptoms();
@@ -26,6 +27,7 @@ class SummaryGenerator
         Summary getSummary();
 
     private:
+        Transcript transcript;
         Summary summary;
 
 };

--- a/qt-app/summarygenerator.h
+++ b/qt-app/summarygenerator.h
@@ -10,15 +10,16 @@
 #ifndef SUMMARYGENERATOR_H
 #define SUMMARYGENERATOR_H
 
-#include "transcript.h"
+#include <QObject>
 #include "summary.h"
 
-class SummaryGenerator
+class SummaryGenerator : public QObject
 {
+    Q_OBJECT
 
     public:
-        SummaryGenerator(const Transcript& transcript);
-        ~SummaryGenerator() = default;
+        explicit SummaryGenerator(QObject *parent = nullptr);
+        virtual ~SummaryGenerator();
 
         SummaryGenerator& summarizeSymptoms();
         SummaryGenerator& summarizeDiagnoses();
@@ -27,7 +28,6 @@ class SummaryGenerator
         Summary getSummary();
 
     private:
-        Transcript transcript;
         Summary summary;
 
 };

--- a/qt-app/summarygenerator.h
+++ b/qt-app/summarygenerator.h
@@ -11,6 +11,7 @@
 #define SUMMARYGENERATOR_H
 
 #include <QObject>
+#include "transcript.h"
 #include "summary.h"
 
 class SummaryGenerator : public QObject
@@ -18,7 +19,7 @@ class SummaryGenerator : public QObject
     Q_OBJECT
 
     public:
-        explicit SummaryGenerator(QObject *parent = nullptr);
+        explicit SummaryGenerator(Transcript& transcript, QObject *parent = nullptr);
         virtual ~SummaryGenerator();
 
         SummaryGenerator& summarizeSymptoms();
@@ -28,6 +29,7 @@ class SummaryGenerator : public QObject
         Summary getSummary();
 
     private:
+        Transcript& transcript;
         Summary summary;
 
 };

--- a/qt-app/transcript.cpp
+++ b/qt-app/transcript.cpp
@@ -1,0 +1,34 @@
+/**
+ * @name transcript.cpp
+ * @brief Definition of Transcript class
+ * 
+ * @author Joelene Hales (jhales5@uwo.ca)
+ * @date Mar. 9, 2025
+ */
+
+#include "transcript.h"
+
+Transcript::Transcript(const QTime& timestamp, const QString& content) : timestamp(timestamp), content(content)
+{
+    // No logic body
+}
+
+/**
+ * @name getTimestamp
+ * @brief Get a read-only version of the transcript timestamp
+ * @return Transcript timestamp
+ */
+const QTime& Transcript::getTimestamp() const
+{
+    return timestamp;
+}
+
+/**
+ * @name getContent
+ * @brief Get a read-only version of the transcript content
+ * @return Transcript content
+ */
+const QString& Transcript::getContent() const
+{
+    return content;
+}

--- a/qt-app/transcript.cpp
+++ b/qt-app/transcript.cpp
@@ -13,6 +13,7 @@ Transcript::Transcript(const QTime& timestamp, const QString& content) : timesta
     // No logic body
 }
 
+
 /**
  * @name getTimestamp
  * @brief Get a read-only version of the transcript timestamp
@@ -22,6 +23,7 @@ const QTime& Transcript::getTimestamp() const
 {
     return timestamp;
 }
+
 
 /**
  * @name getContent

--- a/qt-app/transcript.h
+++ b/qt-app/transcript.h
@@ -1,0 +1,31 @@
+/**
+ * @name transcript.h
+ * @brief Declaration of Transcript class
+ * 
+ * @author Joelene Hales (jhales5@uwo.ca)
+ * @date Mar. 9, 2025
+ */
+
+#ifndef TRANSCRIPT_H
+#define TRANSCRIPT_H
+
+#include <QTime>
+#include <QString>
+
+class Transcript
+{
+
+    public:
+        Transcript(const QTime& timestamp, const QString& content);
+        ~Transcript() = default;   // Qt automatically manages memory of QObjects, no need for manual deletion
+
+        const QTime& getTimestamp() const;
+        const QString& getContent() const;
+
+    private:
+        QTime timestamp;
+        QString content;
+
+};
+
+#endif // TRANSCRIPT_H


### PR DESCRIPTION
Resolves #4

## Summary of Changes

- Adds simple interfaces for the `Transcript` and `SummaryGenerator` classes
   - `Transcript` includes only class members + getters (no JSON serialization/de-serialization)
   - `SummaryGenerator` methods create a `Summary` with simple placeholder text for testing purposes (no LLM functionality)
 