### PR TITLE
Finish Real-Time Transcription Acceptance Criteria + Test Cases and Minor UI Tweaks

### DIFF
--- a/qt-app/mainwindow.cpp
+++ b/qt-app/mainwindow.cpp
@@ -40,7 +40,7 @@ MainWindow::MainWindow(QWidget *parent)
     WindowBuilder::setupUI(centralWidget, btnSettings,
                            lblTitle, lblPatientName, comboSelectPatient,
                            btnRecord, btnSummarize,
-                           selectSummaryLayout, summarySection,
+                           selectSummaryLayout, summarySection, summaryTitle,
                            mainLayout, btnAddPatient, btnEditPatient, btnDeletePatient, btnArchivePatient,
                            toggleSwitch); // Pass toggleSwitch to WindowBuilder
 
@@ -64,9 +64,9 @@ MainWindow::MainWindow(QWidget *parent)
 
     // Add summary layout options
     summaryLayoutOptions = new QMenu(this);
-    QAction *optionDetailedLayout = summaryLayoutOptions->addAction("Detailed Layout");
-    QAction *optionConciseLayout = summaryLayoutOptions->addAction("Concise Layout");
-    QAction *optionPlainLayout = summaryLayoutOptions->addAction("Plain Text");
+    QAction *optionDetailedLayout = summaryLayoutOptions->addAction("Detailed Summary");
+    QAction *optionConciseLayout = summaryLayoutOptions->addAction("Concise Summary");
+    QAction *optionPlainLayout = summaryLayoutOptions->addAction("Plain Text Transcript");
 
     selectSummaryLayout->setMenu(summaryLayoutOptions);
 
@@ -81,13 +81,13 @@ MainWindow::MainWindow(QWidget *parent)
     // Initialize summary layout formatter from settings
     QString defaultSummaryLayout = settings->getSummaryPreference();
     selectSummaryLayout->setText(defaultSummaryLayout);
-    if (defaultSummaryLayout.contains("Detailed Layout"))
+    if (defaultSummaryLayout.contains("Detailed Summary"))
     {
         qDebug() << "Setting default summary format to: Detailed Layout";
         summaryFormatter = new DetailedSummaryFormatter;
         optionDetailedLayout->setEnabled(false);
     }
-    else if (defaultSummaryLayout.contains("Concise Layout"))
+    else if (defaultSummaryLayout.contains("Concise Summary"))
     {
         qDebug() << "Setting default summary format to: Concise Layout";
         summaryFormatter = new ConciseSummaryFormatter;
@@ -283,10 +283,11 @@ void MainWindow::handleSummaryLayoutChanged(SummaryFormatter *summaryFormatter)
         delete child;
     }
 
-    if (selectedOption->text() == "Plain Text")
+    if (selectedOption->text() == "Plain Text Transcript")
     {
         qDebug() << "Switching to plain text (transcript) mode.";
-
+        summaryTitle->setText("Transcript"); // Change section header
+        
         // Ensure the transcript is actually loaded
         if (currentTranscriptText.isEmpty())
         {
@@ -307,6 +308,7 @@ void MainWindow::handleSummaryLayoutChanged(SummaryFormatter *summaryFormatter)
     else
     {
         // Display summary with the selected format
+        summaryTitle->setText("Summary");
         setSummaryFormatter(summaryFormatter);
         displaySummary(summaryGenerator->getSummary());
     }
@@ -876,21 +878,22 @@ void MainWindow::on_patientSelected(int index)
     }
 
     // Revert summary layout according to user summary layout preference.
-    if (defaultLayout.contains("Detailed Layout"))
+    if (defaultLayout.contains("Detailed Summary"))
     {
         summaryFormatter = new DetailedSummaryFormatter;
-        selectSummaryLayout->setText("Detailed Layout");
+        selectSummaryLayout->setText("Detailed Summary");
+
     }
-    else if (defaultLayout.contains("Concise Layout"))
+    else if (defaultLayout.contains("Concise Summary"))
     {
         summaryFormatter = new ConciseSummaryFormatter;
-        selectSummaryLayout->setText("Concise Layout");
+        selectSummaryLayout->setText("Concise Summary");
     }
     else
     {
         qDebug() << "Unrecognized user summary layout. Defaulting to Detailed Layout.";
         summaryFormatter = new DetailedSummaryFormatter;
-        selectSummaryLayout->setText("Detailed Layout");
+        selectSummaryLayout->setText("Detailed Summary");
     }
 
     // Refresh summary layout dropdown

--- a/qt-app/mainwindow.h
+++ b/qt-app/mainwindow.h
@@ -85,6 +85,7 @@ private:
     QPushButton *selectSummaryLayout;
     QMenu *summaryLayoutOptions;
     QVBoxLayout *summarySection;
+    QLabel *summaryTitle;
     QDialog *loadingDialog;
     QLabel *loadingLabel;
     LLMClient *llmClient;

--- a/qt-app/settings.cpp
+++ b/qt-app/settings.cpp
@@ -104,19 +104,19 @@ void Settings::showSettings()
     QMenu *summaryLayoutOptions = new QMenu();
     summaryLayout->addWidget(selectLayoutButton);
 
-    QAction *optionDetailedLayout = summaryLayoutOptions->addAction("Detailed Layout");
-    QAction *optionConciseLayout = summaryLayoutOptions->addAction("Concise Layout");
+    QAction *optionDetailedLayout = summaryLayoutOptions->addAction("Detailed Summary");
+    QAction *optionConciseLayout = summaryLayoutOptions->addAction("Concise Summary");
 
     selectLayoutButton->setMenu(summaryLayoutOptions);
     selectLayoutButton->setText(summaryLayoutPreference);
     mainLayout->addLayout(summaryLayout);
 
     connect(optionDetailedLayout, &QAction::triggered, this, [=]() {
-        setSummaryPreference("Detailed Layout");
+        setSummaryPreference("Detailed Summary");
         selectLayoutButton->setText(summaryLayoutPreference);
     });
     connect(optionConciseLayout, &QAction::triggered, this, [=]() {
-        setSummaryPreference("Concise Layout");
+        setSummaryPreference("Concise Summary");
         selectLayoutButton->setText(summaryLayoutPreference);
     });
 

--- a/qt-app/windowbuilder.cpp
+++ b/qt-app/windowbuilder.cpp
@@ -105,6 +105,7 @@ const QString WindowBuilder::disabledButtonStyle =
  *  @param[in,out] btnSummarize: "Summarize" button
  *  @param[in,out] selectSummaryLayout: Dropdown menu to select summary layout format
  *  @param[in,out] summarySection: Displays the LLM-generated summary
+ *  @param[in,out] summaryTitle: Summary section title
  *  @param[in,out] mainLayout: Main layout which contains all UI elements
  *  @param[in,out] btnAddPatient: "Add Patient" button
  *  @param[in,out] btnEditPatient: "Edit Patient" button
@@ -126,6 +127,7 @@ void WindowBuilder::setupUI(QWidget *centralWidget,
                             QPushButton *&btnSummarize,
                             QPushButton *&selectSummaryLayout,
                             QVBoxLayout *&summarySection,
+                            QLabel *&summaryTitle,
                             QVBoxLayout *&mainLayout,
                             QPushButton *&btnAddPatient,
                             QPushButton *&btnEditPatient,
@@ -144,7 +146,7 @@ void WindowBuilder::setupUI(QWidget *centralWidget,
     btnEditPatient = new QPushButton("Edit", centralWidget);
     btnDeletePatient = new QPushButton("Delete Patient", centralWidget);
     btnArchivePatient = new QPushButton("Archive Patient", centralWidget);
-    QLabel *summaryTitle = new QLabel("Summary");
+    summaryTitle = new QLabel("Summary");
     selectSummaryLayout = new QPushButton(centralWidget);
     selectSummaryLayout->setCheckable(true);
     selectSummaryLayout->setText("Select Summary Layout");

--- a/qt-app/windowbuilder.h
+++ b/qt-app/windowbuilder.h
@@ -59,6 +59,7 @@ public:
                         QPushButton *&btnSummarize,
                         QPushButton *&selectSummaryLayout,
                         QVBoxLayout *&summarySection,
+                        QLabel *&summaryTitle,
                         QVBoxLayout *&mainLayout,
                         QPushButton *&btnAddPatient,
                         QPushButton *&btnEditPatient,


### PR DESCRIPTION
## Context

- To finish the acceptance criteria and test cases associated with User Story: "Real Time Transcription"
    - **Acceptance Criteria 3**: While transcription is active, the doctor can navigate previous transcriptions and patient data within the current patient’s page.
    - **Acceptance Criteria 4**: The user remains locked into the patient’s page during active transcription but can freely navigate within that page.
    - **Test Case 4**: Navigate through previous transcriptions and patient data during an active transcription and ensure the system remains stable
    - **Test Case 5**: Confirm that the user cannot accidentally leave the current patient’s page while transcription is ongoing.
    
## Summary of Changes

### Page Navigation During Real-Time Transcription

While recording and transcription is in progress...

- The following buttons are disabled
    - Add patient
    - Delete patient
    - Archive patient
    - View archived patients
    - Settings
    - Summarize
    - Select patients dropdown
- The only options available are to edit patient information and switch summary layouts (ie. navigate through past transcripts)
- Loading dialog box displayed while transcription is ongoing is no longer modal, meaning it can be closed by the user to view the other transcripts/summaries


### Miscellaneous UI Changes

- Change the name of each summary layout in the dropdown to better differentiate what is a summary vs what is a transcript:
   - "Detailed Layout" -> "Detailed Summary"
   - "Concise Layout" -> "Concise Summary"
   - "Plain Text" -> "Plain Text Transcription"
 - If viewing the Plain Text Transcription, the "Summary" section title changes to "Transcript"